### PR TITLE
Update package name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,9 @@
 {
-    "name": "Denysslav/Powerdns-client",
+    "name": "denysslav/powerdns-client",
     "description": "A PHP client for PowerDNS http api",  
     "keywords": ["powerdns", "pdns", "pdns-server", "powerdns-server", "api", "dns"],
     "type": "library",
-    "homepage": "https://github.com/Denysslav/PowerDNS-client",  
+    "homepage": "https://github.com/denysslav/powerdns-client",  
     "authors": [
         {
             "name": "Denyslav Parvanov",


### PR DESCRIPTION
Packagist.org doesn't uppercase in package name.

Error message from packagist.org: "The package name Denysslav/Powerdns-client is invalid, it should not contain uppercase characters. We suggest using denysslav/powerdns-client instead."
